### PR TITLE
Write a SQL Query to add a Book

### DIFF
--- a/queries/add_book.sql
+++ b/queries/add_book.sql
@@ -1,0 +1,2 @@
+INSERT INTO "Book" ("title", "authorId", "ISBN") 
+VALUES ('Harry Potter and the Chamber of Secrets', 2, '9780439064866');


### PR DESCRIPTION
Manual SQL queries can be found in the folder `queries`. This took an embarrassingly long time because I had to figure out that Postgres is case-sensitive and so requires double-quotes in case-sensitive names; in the past this has either been irrelevant or I've used clients to write SQL, so I never ran into this.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `add_book.sql` to insert a book into the `Book` table with case-sensitive names.
> 
>   - **SQL Query**:
>     - Adds `add_book.sql` to `queries` folder to insert a book into the `Book` table.
>     - Uses double quotes for case-sensitive table and column names in Postgres.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Falangarber-databases&utm_source=github&utm_medium=referral)<sup> for 8849d26cbd3fe52acb9983d49cb7c8e93f46ee3b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->